### PR TITLE
feat: Add config property to translation functions and enhance type definitions

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -4,6 +4,32 @@
 <br/>
 
 <details>
+<summary><h3> <strong>Version [0.5.2]</strong> &mdash; <i>2025/10/18<i/></h3></summary>
+
+- Added `config` property to `Translate_F2` type and `_translation`
+  function return value
+- Enhanced `__Translations` and `_RequiredTranslations` to preserve exact
+  parameter strings with `ExtractParamString`
+- Added `ExtractParamString` utility type to extract and preserve parameter
+  patterns from template strings
+- Simplified `translation.derived` and `translation.fromMachine` type
+  casting
+- Added `CheckParams` utility type for better parameter validation
+- Improved type inference for `CustomMessage` in translations to maintain
+  exact parameter positions
+- Enhanced tuple handling in translation types from `any[]` to proper tuple
+  types `[infer A, ...infer Rest]`
+- Added comprehensive tests for `translation.derived` with nested
+  configurations
+- Updated type tests to verify exact parameter string patterns in
+  `CustomMessage`
+- 🧪 **100%** _coverage_
+
+</details>
+
+<br/>
+
+<details>
 <summary><h3> <strong>Version [0.5.1]</strong> &mdash; <i>2025/10/18<i/></h3></summary>
 
 - Updated `I18nMessage` type to include `LanguageMessages`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,48 @@
 # @bemedev/i18n
 
 A modern, fully-typed internationalization (i18n) library for TypeScript
-and JavaScript with a fluent, composable API. Define once, compose
-per-locale, and translate safely with strong types.
+and JavaScript with a fluent, composable API. Define once, compose per-lo//
+Locales are narrowed from machine.keys const call =
+machine.translate('greetings', { name: 'A' }).to; // call: (locale?: 'en' |
+'es-ES' | 'en-US') => string
+
+````
+
+### Utility types
+
+If you need to extract types from your i18n machine, several utility types
+are provided:
+
+```ts
+import type {
+  ConfigFrom,        // Extract the configuration type
+  KeysFrom,          // Extract available locale keys
+  TranslationsFrom,  // Extract all translations
+  TranslationFrom,   // Extract a single locale translation
+  KeyFrom,           // Extract the current locale key
+} from '@bemedev/i18n/class';
+
+import type {
+  RequiredTranslations,  // Make all translations required
+  _Translations,         // Make all translations optional
+  _Params,              // Extract parameters for a translation key
+  CheckParams,          // Validate parameter requirements
+} from '@bemedev/i18n/types';
+
+// Example usage
+type Config = ConfigFrom<typeof machine>;
+type Locales = KeysFrom<typeof machine>;
+type AllTranslations = TranslationsFrom<typeof machine>;
+type EnglishTranslation = TranslationFrom<typeof machine>;
+
+// Extract parameters for a specific key
+type GreetingParams = _Params<Config, 'greetings'>;
+// => { name: string; lastLoginDate: Date }
+````
+
+**Note:** Properties prefixed with `__` (like `__key`, `__translation`) are
+internal and marked as deprecated. They exist only for type inference and
+should not be used at runtime.te safely with strong types.
 
 ## Features
 
@@ -163,8 +203,50 @@ machine.translate('unknown.key'); // ❌ unknown key
 
 // Locales are narrowed from machine.keys
 const call = machine.translate('greetings', { name: 'A' }).to;
-// call: (locale?: 'en' | 'es-ES' | 'en-US') => string
+// // call: (locale?: 'en' | 'es-ES' | 'en-US') => string
 ```
+
+### Utility types
+
+If you need to extract types from your i18n machine, several utility types
+are provided:
+
+```ts
+import type {
+  ConfigFrom, // Extract the configuration type
+  KeysFrom, // Extract available locale keys
+  TranslationsFrom, // Extract all translations
+  TranslationFrom, // Extract a single locale translation
+  KeyFrom, // Extract the current locale key
+} from '@bemedev/i18n/class';
+
+import type {
+  RequiredTranslations, // Make all translations required
+  _Translations, // Make all translations optional
+  _Params, // Extract parameters for a translation key
+  CheckParams, // Validate parameter requirements
+} from '@bemedev/i18n/types';
+
+// Example usage
+type Config = ConfigFrom<typeof machine>;
+type Locales = KeysFrom<typeof machine>;
+type AllTranslations = TranslationsFrom<typeof machine>;
+type EnglishTranslation = TranslationFrom<typeof machine>;
+
+// Extract parameters for a specific key
+type GreetingParams = _Params<Config, 'greetings'>;
+// => { name: string; lastLoginDate: Date }
+```
+
+**Note:** Properties prefixed with `__` (like `__key`, `__translation`) are
+internal and marked as deprecated. They exist only for type inference and
+should not be used at runtime.
+
+---
+
+## Advanced Usage
+
+````
 
 If you want to re-use the machine’s internal types, utility types are
 provided:
@@ -177,7 +259,7 @@ import type {
   TranslationsFrom,
   TranslationFrom, // @deprecated – internal typing only
 } from '@bemedev/i18n/class';
-```
+````
 
 Note: properties prefixed by ** (like `**key`, `\_\_translation`) are
 marked as deprecated and exist only to carry types. Don’t use them at
@@ -185,64 +267,112 @@ runtime.
 
 ---
 
-## NB:
+## Advanced Usage
 
-If you want to create a new translation based on an existing one, but only
-use types, not full object use `translationFrom`
+### Creating translations from existing configurations
+
+If you want to create a new translation based on an existing configuration
+without copying the entire object, use the `translation` helper:
+
+#### Basic usage with `translation`
 
 ```ts
-import { translationFrom } from '@bemedev/i18n';
+import { translation } from '@bemedev/i18n';
 
-const translate = translationFrom({
-  greeting: 'Hello',
-  farewell: 'Goodbye',
-  withParam: 'Hello {name}!',
-  nested: {
-    welcome: 'Welcome back',
-    deep: {
-      message: 'Deep message',
+const translate = translation(
+  {
+    greeting: 'Hello',
+    farewell: 'Goodbye',
+    withParam: 'Hello {name}!',
+    nested: {
+      welcome: 'Welcome back',
+      deep: {
+        message: 'Deep message',
+      },
     },
   },
-});
+  'en',
+);
 
-describe('#01 => should translate simple keys', () => {
-  test('#01 => greeting key', () => {
-    expect(translate('greeting')).toBe('Hello');
-  });
+// Simple translations
+translate('greeting'); // => 'Hello'
+translate('farewell'); // => 'Goodbye'
 
-  test('#02 => farewell key', () => {
-    expect(translate('farewell')).toBe('Goodbye');
-  });
-});
+// With parameters
+translate('withParam', { name: 'John' }); // => 'Hello John!'
 
-test('#02 => should translate with parameters', () => {
-  expect(translate('withParam', { name: 'John' })).toBe('Hello John!');
-});
+// Nested keys
+translate('nested.welcome'); // => 'Welcome back'
+translate('nested.deep.message'); // => 'Deep message'
 ```
 
-or with a default fallback config
+#### Using `translation.derived` for type-safe derived translations
+
+Create translations that derive from an existing configuration while
+maintaining full type safety:
 
 ```ts
-import { translationFrom } from '@bemedev/i18n';
+import { translation } from '@bemedev/i18n';
+import { machine } from './your-base-config';
 
-const rootConfig = {
-  greeting: 'Hello',
-  user: {
-    name: 'Default User',
-  },
-} as const;
+const spanishTranslation = translation.derived<typeof machine.config>(
+  dt => ({
+    localee: 'es-ES',
+    greetings: dt(
+      '¡Hola {name}! Tu última conexión fue el {lastLoginDate:date}.',
+      {
+        date: {
+          lastLoginDate: {
+            month: '2-digit',
+            year: 'numeric',
+            day: '2-digit',
+          },
+        },
+      },
+    ),
+    nested: {
+      greetings: dt('¡Hola {names:list}!'),
+    },
+  }),
+  'es-ES',
+);
 
-const translate = translationFrom.complete(rootConfig, {
-  greeting: 'Bonjour',
+// Fully typed translations
+spanishTranslation('greetings', {
+  name: 'Juan',
+  lastLoginDate: new Date('2024-06-15T12:00:00Z'),
 });
+// => '¡Hola Juan! Tu última conexión fue el 15/06/2024.'
+```
 
-test('#01 => overridden greeting translation', () => {
-  expect(translate('greeting')).toBe('Bonjour');
-});
+#### Using `translation.fromMachine` for machine-based translations
 
-test('#02 => fallback to root config for user name', () => {
-  expect(translate('user.name')).toBe('Default User'); // Should access root config
-});
+Create translations directly from an existing i18n machine:
+
+```ts
+import { translation } from '@bemedev/i18n';
+import { machine } from './your-machine';
+
+const germanTranslation = translation.fromMachine<typeof machine>(
+  dt => ({
+    localee: 'de-DE',
+    greetings: dt(
+      'Hallo {name}! Deine letzte Anmeldung war {lastLoginDate:date}.',
+    ),
+    // ... other translations
+  }),
+  'de-DE',
+);
+```
+
+### Accessing the configuration
+
+The `translation` function returns an object with a `config` property that
+exposes the underlying configuration:
+
+```ts
+const translate = translation({ greeting: 'Hello' }, 'en');
+console.log(translate.config); // => { greeting: 'Hello' }
 ```
 
 ## Licence
@@ -266,7 +396,7 @@ The Youtube video that inspired this library can be found
 
 <br/>
 
-## Auteur
+## Author
 
 chlbri (bri_lvi@icloud.com)
 
@@ -278,7 +408,7 @@ chlbri (bri_lvi@icloud.com)
 
 <br/>
 
-## Liens
+## Mainfull Links
 
 - [Documentation](https://github.com/chlbri/i18n)
-- [Signaler un problème](https://github.com/chlbri/i18n/issues)
+- [Signal a bug](https://github.com/chlbri/i18n/issues)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bemedev/i18n",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Internationalization library for Bemedev projects, providing utilities for managing translations and locale-specific content.",
   "author": {
     "email": "bri_lvi@icloud.com",

--- a/src/__tests__/translation.test.ts
+++ b/src/__tests__/translation.test.ts
@@ -210,8 +210,139 @@ describe('#01 => translation', () => {
   });
 });
 
+const derived1 = translation.derived<typeof machine.config>(
+  dt => ({
+    localee: 'es-ES',
+    greetings: dt(
+      '¡Hola {name}! Tu última conexión fue el {lastLoginDate:date}.',
+      {
+        date: {
+          lastLoginDate: {
+            month: '2-digit',
+            year: 'numeric',
+            day: '2-digit',
+          },
+        },
+      },
+    ),
+
+    fdfd: '',
+    inboxMessages: dt('Hola {name}, tienes {messages:plural}.', {
+      plural: {
+        messages: {
+          one: '1 mensaje',
+          other: '{?} mensajes',
+          two: '2 mensajes',
+        },
+      },
+    }),
+
+    hobby: dt('Elegiste {hobby:enum} como tu pasatiempo.', {
+      enum: {
+        hobby: { runner: 'corredor', developer: 'desarrollador' },
+      },
+    }),
+
+    nested: {
+      greetings: dt('¡Hola {names:list}!'),
+      data: { lang: 'es', langs: ['fr', 'gb', 'en'] },
+      one: dt('Line {LINE} is empty', {}),
+      someArray: ['cadena1', 'cadena2'],
+    },
+
+    jerseyNumber: dt('Tu número es {jersey:number}.', {
+      number: {
+        jersey: {},
+      },
+    }),
+  }),
+  'es-ES',
+);
 describe('#02 => translation.derived', () => {
-  const func = translation.derived<typeof machine.config>(
+  derived1('localee');
+
+  derived1('nested', {
+    'nested.greetings': { names: ['Ana', 'Luis', 'María'] },
+    'nested.one': { LINE: 'string' },
+  });
+
+  const { acceptation, success } = createTests(derived1 as any);
+
+  describe('#00 => Acceptation', acceptation);
+
+  describe(
+    '#01 => Success',
+    success(
+      {
+        invite: 'localee',
+        parameters: 'localee',
+        expected: 'es-ES',
+      },
+      {
+        invite: 'greetings',
+        parameters: [
+          'greetings',
+          {
+            name: 'Juan',
+            lastLoginDate: new Date('2024-06-15T12:00:00Z'),
+          },
+        ],
+        expected: '¡Hola Juan! Tu última conexión fue el 15/06/2024.',
+      },
+      {
+        invite: 'inboxMessages with one message',
+        parameters: ['inboxMessages', { name: 'Juan', messages: 1 }],
+        expected: 'Hola Juan, tienes 1 mensaje.',
+      },
+      {
+        invite: 'inboxMessages with multiple messages',
+        parameters: ['inboxMessages', { name: 'Juan', messages: 3 }],
+        expected: 'Hola Juan, tienes 3 mensajes.',
+      },
+      {
+        invite: 'inboxMessages with 0 messages',
+        parameters: ['inboxMessages', { name: 'Juan', messages: 0 }],
+        expected: 'Hola Juan, tienes 0 mensajes.',
+      },
+      {
+        invite: 'hobby as developer',
+        parameters: ['hobby', { hobby: 'developer' }],
+        expected: 'Elegiste desarrollador como tu pasatiempo.',
+      },
+      {
+        invite: 'hobby as runner',
+        parameters: ['hobby', { hobby: 'runner' }],
+        expected: 'Elegiste corredor como tu pasatiempo.',
+      },
+      {
+        invite: 'nested.greetings',
+        parameters: [
+          'nested.greetings',
+          { names: ['Ana', 'Luis', 'María'] },
+        ],
+        expected: '¡Hola Ana, Luis y María!',
+      },
+      {
+        invite: 'jerseyNumber',
+        parameters: ['jerseyNumber', { jersey: 23.0001 }],
+        expected: 'Tu número es 23.',
+      },
+      {
+        invite: 'nested.data.lang',
+        parameters: 'nested.data.lang',
+        expected: 'es',
+      },
+      {
+        invite: 'nested.data',
+        parameters: 'nested.data',
+        expected: { lang: 'es', langs: ['fr', 'gb', 'en'] },
+      },
+    ),
+  );
+});
+
+describe('#03 => translation.derived #2', () => {
+  const func = translation.derived<typeof derived1.config>(
     dt => ({
       localee: 'es-ES',
       greetings: dt(
@@ -342,7 +473,92 @@ describe('#02 => translation.derived', () => {
   );
 });
 
-describe('#03 => translation.fromMachine', () => {
+describe('#04 => translation and derive', () => {
+  const func = translation(derived1.config, 'es-ES');
+
+  func('localee');
+
+  func('nested', {
+    'nested.greetings': { names: ['Ana', 'Luis', 'María'] },
+    'nested.one': { LINE: 'string' },
+  });
+
+  const { acceptation, success } = createTests(func as any);
+
+  describe('#00 => Acceptation', acceptation);
+
+  describe(
+    '#01 => Success',
+    success(
+      {
+        invite: 'localee',
+        parameters: 'localee',
+        expected: 'es-ES',
+      },
+      {
+        invite: 'greetings',
+        parameters: [
+          'greetings',
+          {
+            name: 'Juan',
+            lastLoginDate: new Date('2024-06-15T12:00:00Z'),
+          },
+        ],
+        expected: '¡Hola Juan! Tu última conexión fue el 15/06/2024.',
+      },
+      {
+        invite: 'inboxMessages with one message',
+        parameters: ['inboxMessages', { name: 'Juan', messages: 1 }],
+        expected: 'Hola Juan, tienes 1 mensaje.',
+      },
+      {
+        invite: 'inboxMessages with multiple messages',
+        parameters: ['inboxMessages', { name: 'Juan', messages: 3 }],
+        expected: 'Hola Juan, tienes 3 mensajes.',
+      },
+      {
+        invite: 'inboxMessages with 0 messages',
+        parameters: ['inboxMessages', { name: 'Juan', messages: 0 }],
+        expected: 'Hola Juan, tienes 0 mensajes.',
+      },
+      {
+        invite: 'hobby as developer',
+        parameters: ['hobby', { hobby: 'developer' }],
+        expected: 'Elegiste desarrollador como tu pasatiempo.',
+      },
+      {
+        invite: 'hobby as runner',
+        parameters: ['hobby', { hobby: 'runner' }],
+        expected: 'Elegiste corredor como tu pasatiempo.',
+      },
+      {
+        invite: 'nested.greetings',
+        parameters: [
+          'nested.greetings',
+          { names: ['Ana', 'Luis', 'María'] },
+        ],
+        expected: '¡Hola Ana, Luis y María!',
+      },
+      {
+        invite: 'jerseyNumber',
+        parameters: ['jerseyNumber', { jersey: 23.0001 }],
+        expected: 'Tu número es 23.',
+      },
+      {
+        invite: 'nested.data.lang',
+        parameters: 'nested.data.lang',
+        expected: 'es',
+      },
+      {
+        invite: 'nested.data',
+        parameters: 'nested.data',
+        expected: { lang: 'es', langs: ['fr', 'gb', 'en'] },
+      },
+    ),
+  );
+});
+
+describe('#05 => translation.fromMachine', () => {
   const func = translation.fromMachine<typeof machine>(
     dt => ({
       localee: 'es-ES',

--- a/src/__tests__/types.test-d.ts
+++ b/src/__tests__/types.test-d.ts
@@ -6,9 +6,14 @@ import type {
   TranslationFrom,
   TranslationsFrom,
 } from '../class';
-import type { DateArgs, LanguageMessages } from '../types';
-import { machine } from './fixtures';
 import type { CustomMessage } from '../message';
+import type {
+  _Params,
+  DateArgs,
+  LanguageMessages,
+  RequiredTranslations,
+} from '../types';
+import { machine } from './fixtures';
 
 expectTypeOf<typeof machine.translate>().toExtend<types.Fn>();
 expectTypeOf<typeof machine.translate>().toBeFunction();
@@ -56,15 +61,17 @@ expectTypeOf(machine.translations).toEqualTypeOf<
 
 const trnGreet = machine.translations['en-US'].greetings;
 expectTypeOf(trnGreet).toEqualTypeOf<
-  | string
   | CustomMessage<
-      string,
+      `${string}{name}${string}{lastLoginDate:date}${string}`,
       {
-        date?: DateArgs<'lastLoginDate'> | undefined;
+        date?: DateArgs<'lastLoginDate'>;
       }
     >
   | undefined
 >();
+
+export const ddd: `${string}{name}${string}{lastLoginDate:date}${string}` =
+  'Hello {name}{lastLoginDate:date}.';
 
 expectTypeOf(machine.translations.en).toEqualTypeOf<
   TranslationFrom<typeof machine>
@@ -86,3 +93,9 @@ expectTypeOf(machine.__key).toEqualTypeOf<KeyFrom<typeof machine>>();
 
 expectTypeOf(machine.config).toExtend<LanguageMessages>();
 expectTypeOf(machine.config).toEqualTypeOf<ConfigFrom<typeof machine>>();
+
+type RT1 = RequiredTranslations<typeof machine.config>;
+
+expectTypeOf<_Params<RT1, 'greetings'>>().toEqualTypeOf<
+  _Params<typeof machine.config, 'greetings'>
+>();

--- a/src/class.ts
+++ b/src/class.ts
@@ -63,20 +63,17 @@ class I18n<
     else this.#translations[key] = func;
   };
 
-  provideTranslation = <K extends string, V extends Tr>(
+  provideTranslation = <const K extends string, V extends Tr>(
     key: K,
     func: ((define: typeof defineTranslation) => V) | V,
-  ) => {
-    const out = new I18n<R, [...Keys, K]>(
-      this._config,
-      ...(this.#initials as any),
-    );
+  ): I18n<R, [...Keys, K]> => {
+    const out = new I18n(this._config, ...(this.#initials as any));
 
     out.#translations = { ...this.#translations };
 
     out.#addTranslation(key, func);
 
-    return out;
+    return out as any;
   };
 
   #getOrderedLocaleAndParentLocales = (locale?: string) => {

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -16,6 +16,7 @@ const _translation = <const R extends LanguageMessages>(
 
   const out = (...args: any[]) =>
     (_class as any).translate(...args).to(locale);
+  out.config = config;
 
   return out as Translate_F2<R>;
 };
@@ -44,10 +45,10 @@ translation.derived = <const R extends LanguageMessages>(
     | RequiredTranslations<R>,
   locale = 'en-US',
 ) => {
-  return translation<R>(func as any, locale);
+  return translation(func, locale);
 };
 
 translation.fromMachine = <const T extends Simple18>(
   func: ((define: typeof defineTranslation) => infer18<T>) | infer18<T>,
   locale = 'en-US',
-) => translation<T['config']>(func, locale);
+) => translation(func, locale);

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,11 @@ export type ExtractParamOptions<S extends string> =
       : ExtractParamOptions<Rest> // If the string has no parameter type
     : unknown; // If the string has no parameters
 
+export type ExtractParamString<S extends string> =
+  S extends `${string}{${infer Param}}${infer Rest}`
+    ? `${string}{${Param}}${ExtractParamString<Rest>}`
+    : string;
+
 export type DefineTransition_F = <
   S extends string,
   O extends ExtractParamOptions<S>,
@@ -80,10 +85,10 @@ export type DefineTransition_F = <
 ) => CustomMessage<S, O>;
 
 type __Translations<R> =
-  R extends CustomMessage<string, infer A>
-    ? CustomMessage<string, A> | string
-    : R extends any[]
-      ? __Translations<R[number]>[]
+  R extends CustomMessage<infer S, infer A>
+    ? CustomMessage<ExtractParamString<S>, A>
+    : R extends [infer A, ...infer Rest]
+      ? [__Translations<A>, ...__Translations<Rest>]
       : R extends object
         ? {
             [K in keyof R]?: __Translations<R[K]>;
@@ -96,8 +101,8 @@ export type _Translations<R extends LanguageMessages> = Extract<
 >;
 
 type _RequiredTranslations<R> =
-  R extends CustomMessage<string, infer A>
-    ? CustomMessage<string, A>
+  R extends CustomMessage<infer S, infer A>
+    ? CustomMessage<ExtractParamString<S>, A>
     : R extends [infer A, ...infer Rest]
       ? [_RequiredTranslations<A>, ..._RequiredTranslations<Rest>]
       : R extends object
@@ -199,18 +204,29 @@ export type _Params<Translations, S extends string> =
     Translations,
     S
   >
-    ? A[0] extends Array<string>
-      ? unknown
-      : ExtractParamArgs<
-          Extract<A[0], string>,
-          A[1] extends {
-            enum: infer E;
-          }
-            ? keyof E extends never
-              ? EnumMap
-              : E
-            : EnumMap
-        >
+    ? ExtractParamArgs<
+        Extract<A[0], string>,
+        A[1] extends {
+          enum: infer E;
+        }
+          ? keyof E extends never
+            ? EnumMap
+            : E
+          : EnumMap
+      >
+    : never;
+
+export type CheckParams<Translations, S extends string> =
+  NormalizedTranslationAtKeyWithParams<
+    Translations,
+    S
+  > extends infer A extends NormalizedTranslationAtKeyWithParams<
+    Translations,
+    S
+  >
+    ? unknown extends A[1]
+      ? never
+      : A[1]
     : never;
 
 export type PathsWithParams<T extends object> = keyof Decompose<
@@ -280,18 +296,21 @@ export type Translate_F2<
   Pn extends string = PathsWithNoParams<R>,
   Pp extends string = PathsWithParams<R>,
   KS extends keyof D & string = Exclude<keyof D, Pn | Pp> & string,
-> = <const S extends KS | Pp | Pn>(
-  key: S,
-  ...args: S extends Pp
-    ? [_Params<R, S>]
-    : Extract<Pp, `${S}.${string}`> extends never
-      ? []
-      : [
-          args: {
-            [K in Extract<Pp, `${S}.${string}`>]: _Params<R, K>;
-          },
-        ]
-) => S extends KS ? D[S] : string;
+> = {
+  <const S extends KS | Pp | Pn>(
+    key: S,
+    ...args: S extends Pp
+      ? [_Params<R, S>]
+      : Extract<Pp, `${S}.${string}`> extends never
+        ? []
+        : [
+            args: {
+              [K in Extract<Pp, `${S}.${string}`>]: _Params<R, K>;
+            },
+          ]
+  ): S extends KS ? D[S] : string;
+  config: R;
+};
 
 export type KeyU<S extends types.Keys> = Record<S, unknown>;
 


### PR DESCRIPTION
- Added `config` property to `Translate_F2` type and `_translation` function return value
- Enhanced `__Translations` and `_RequiredTranslations` to preserve exact parameter strings with `ExtractParamString`
- Added `ExtractParamString` utility type to extract and preserve parameter patterns from template strings
- Simplified `translation.derived` and `translation.fromMachine` type casting
- Added `CheckParams` utility type for better parameter validation
- Improved type inference for `CustomMessage` in translations to maintain exact parameter positions
- Enhanced tuple handling in translation types from `any[]` to proper tuple types `[infer A, ...infer Rest]`
- Added comprehensive tests for `translation.derived` with nested configurations
- Updated type tests to verify exact parameter string patterns in `CustomMessage`
- Bumped version to 0.5.2